### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cd termius-rpm
 
 2. Install the build dependencies
 ```bash
-sudo dnf install -y rpmdevtools rpm-build rpm-devel rpmlint bsdtar
+sudo dnf install -y rpmdevtools rpm-build rpm-devel rpmlint bsdtar libappindicator-gtk3
 ```
 
 3. Set up development build tree, download Termius deb to it and build the package.


### PR DESCRIPTION
Add the `libappindicator-gtk3` dependency in the README that is needed to compile the rpm.