### PR TITLE
fix: issue with running rpmbuild --target x86_64 -bb termius-app.spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cd termius-rpm
 
 2. Install the build dependencies
 ```bash
-sudo dnf install -y rpmdevtools rpm-build rpm-devel rpmlint bsdtar
+sudo dnf install -y rpmdevtools rpm-build rpm-devel rpmlint bsdtar libXScrnSaver libappindicator-gtk3
 ```
 
 3. Set up development build tree, download Termius deb to it and build the package.


### PR DESCRIPTION
When running
```bash
rpmbuild --target x86_64 -bb termius-app.spec
```
This is shown in the terminal
```bash
Building target platforms: x86_64
Building for target x86_64
warning: %source_date_epoch_from_changelog is set, but %changelog has no entries to take a date from
error: Failed build dependencies:
	libXScrnSaver is needed by termius-app-9.26.0-1.fc42.x86_64
	libappindicator-gtk3 is needed by termius-app-9.26.0-1.fc42.x86_64
```
This Pull Request adds the 2 missing libraries in the README.md file